### PR TITLE
Add gaps to missing conseq cols

### DIFF
--- a/src/seq_utils.cpp
+++ b/src/seq_utils.cpp
@@ -61,7 +61,7 @@ char get_dna_from_pos(set<int> ins){
     if(ins.count(3)==1){
         return 'T';
     }
-    return("-");
+    return('-');
 }
 
 set<int> get_dna_pos(char inc){


### PR DESCRIPTION
In the case where a column contains no recognized characters, produce a '-' character instead of a null char.
