### PR TITLE
binaries go in bin, not prefix

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -536,10 +536,10 @@ pxcolt: $(CPP_OBJS) $(COLLAPSE_TREE_OBJ)
 	$(CXX) -o "pxcolt" $(OPT_FLAGS) $(COLLAPSE_TREE_OBJ) $(CPP_OBJS)
 
 install:
-	install -m 0755 px* $(prefix)
+	install -m 0755 px* $(prefix)/bin
 
 uninstall:
-	-$(RM) $(prefix)/px*
+	-$(RM) $(prefix)/bin/px*
 
 # Other Targets
 clean:


### PR DESCRIPTION
I am currently packaging this for Homebrew and tripped over this. Binaries should be installed in bin, not prefix. There are other things that should be changed (e.g., the uninstall target is extremely dangerous) but this is the most egregious. 

See https://www.gnu.org/prep/standards/html_node/Directory-Variables.html for rationale. 