### PR TITLE
Fix configure detection for nlopt on Linux

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -18,7 +18,7 @@ AC_PREFIX_DEFAULT(/usr/local/bin)
 
 have_nlopt=no
 AC_SUBST([HNLOPT],[Y])
-AC_SEARCH_LIBS([nlopt_urand], [nlopt_cxx], [have_nlopt=yes])
+AC_SEARCH_LIBS([nlopt_urand], [nlopt_cxx], [have_nlopt=yes], [have_nlopt=no], [-lstdc++])
 
 if test "x${have_nlopt}" = xno; then
    AC_MSG_WARN([


### PR DESCRIPTION
gcc by default does not link in the C++ standard library when called as `gcc`. The configure script would correctly detect the presence of `libnlopt_cxx.so` but would linking would fail as `libnlopt_cxx` needs to also link against the C++ standard library. (`AC_SEARCH_LIBS` is intended for C linking, not C++ so it wouldn't make sense for it to be calling `g++` anyway).

The configure script will also need to be regenerated.

Relevant output from config.log:

```
configure:3310: checking for library containing nlopt_urand
configure:3341: gcc-5 -o conftest -g -O2   conftest.c -lm  >&5
/tmp/cc55HnBC.o: In function `main':
/tmp/phyx-20180519-6669-u0th0x/phyx-0.99/src/conftest.c:21: undefined reference to `nlopt_urand'
collect2: error: ld returned 1 exit status
configure:3341: $? = 1
configure: failed program was:
| /* confdefs.h */
| #define PACKAGE_NAME "phyx"
| #define PACKAGE_TARNAME "phyx"
| #define PACKAGE_VERSION "1.0"
| #define PACKAGE_STRING "phyx 1.0"
| #define PACKAGE_BUGREPORT "eebsmith@umich.edu"
| #define PACKAGE_URL ""
| #define HAVE_LIBM 1
| /* end confdefs.h.  */
| 
| /* Override any GCC internal prototype to avoid an error.
|    Use char because int might match the return type of a GCC
|    builtin and then its argument prototype would still apply.  */
| #ifdef __cplusplus
| extern "C"
| #endif
| char nlopt_urand ();
| int
| main ()
| {
| return nlopt_urand ();
|   ;
|   return 0;
| }
configure:3341: gcc -o conftest -g -O2   conftest.c -lnlopt_cxx  -lm  >&5
libnlopt_cxx.so: undefined reference to `std::ostream& std::ostream::_M_insert<unsigned long>(unsigned long)'
libnlopt_cxx.so: undefined reference to `std::ctype<char>::_M_widen_init() const'
libnlopt_cxx.so: undefined reference to `operator delete(void*)'
libnlopt_cxx.so: undefined reference to `operator new[](unsigned long)'
libnlopt_cxx.so: undefined reference to `__cxa_end_catch'
libnlopt_cxx.so: undefined reference to `std::cout'
libnlopt_cxx.so: undefined reference to `std::basic_ostream<char, std::char_traits<char> >& std::operator<< <std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*)'
libnlopt_cxx.so: undefined reference to `std::ostream& std::ostream::_M_insert<double>(double)'
libnlopt_cxx.so: undefined reference to `std::ostream::flush()'
libnlopt_cxx.so: undefined reference to `std::ios_base::Init::~Init()'
libnlopt_cxx.so: undefined reference to `std::ostream::put(char)'
libnlopt_cxx.so: undefined reference to `std::__throw_bad_cast()'
libnlopt_cxx.so: undefined reference to `std::__detail::_List_node_base::_M_unhook()'
libnlopt_cxx.so: undefined reference to `operator delete[](void*)'
libnlopt_cxx.so: undefined reference to `__gxx_personality_v0'
libnlopt_cxx.so: undefined reference to `std::basic_ios<char, std::char_traits<char> >::clear(std::_Ios_Iostate)'
libnlopt_cxx.so: undefined reference to `__cxa_begin_catch'
libnlopt_cxx.so: undefined reference to `__cxa_rethrow'
libnlopt_cxx.so: undefined reference to `std::ios_base::Init::Init()'
libnlopt_cxx.so: undefined reference to `vtable for __cxxabiv1::__si_class_type_info'
libnlopt_cxx.so: undefined reference to `operator new(unsigned long)'
libnlopt_cxx.so: undefined reference to `std::__detail::_List_node_base::_M_transfer(std::__detail::_List_node_base*, std::__detail::_List_node_base*)'
libnlopt_cxx.so: undefined reference to `std::__detail::_List_node_base::_M_hook(std::__detail::_List_node_base*)'
libnlopt_cxx.so: undefined reference to `vtable for __cxxabiv1::__class_type_info'
libnlopt_cxx.so: undefined reference to `std::ostream::operator<<(int)'
libnlopt_cxx.so: undefined reference to `std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*, long)'
libnlopt_cxx.so: undefined reference to `vtable for __cxxabiv1::__vmi_class_type_info'
collect2: error: ld returned 1 exit status
```